### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/910/905/101910905.geojson
+++ b/data/101/910/905/101910905.geojson
@@ -170,6 +170,9 @@
         "wk:page":"Apatin"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a8638ad3fa0943c31366bbf22a50638c",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":101910905,
-    "wof:lastmodified":1563589059,
+    "wof:lastmodified":1582313339,
     "wof:name":"Apatin",
     "wof:parent_id":1108809815,
     "wof:placetype":"locality",

--- a/data/101/910/927/101910927.geojson
+++ b/data/101/910/927/101910927.geojson
@@ -182,6 +182,9 @@
         "wk:page":"Sremski Karlovci"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"150a99d99ee6df92de5b764b310c91c3",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":101910927,
-    "wof:lastmodified":1563589061,
+    "wof:lastmodified":1582313339,
     "wof:name":"Sremski Karlovci",
     "wof:parent_id":1108810091,
     "wof:placetype":"locality",

--- a/data/101/910/929/101910929.geojson
+++ b/data/101/910/929/101910929.geojson
@@ -174,6 +174,9 @@
         "wk:page":"Vr\u0161ac"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f12d086aaff724d8d50217d9b826fb05",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":101910929,
-    "wof:lastmodified":1563589060,
+    "wof:lastmodified":1582313339,
     "wof:name":"Vr\u00b5ac",
     "wof:parent_id":1108810153,
     "wof:placetype":"locality",

--- a/data/101/910/935/101910935.geojson
+++ b/data/101/910/935/101910935.geojson
@@ -185,6 +185,9 @@
         "wk:page":"Be\u010dej"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a2b373c99d1e737a410dd700c887cd11",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":101910935,
-    "wof:lastmodified":1563589058,
+    "wof:lastmodified":1582313339,
     "wof:name":"Be\u010dej",
     "wof:parent_id":1108809841,
     "wof:placetype":"locality",

--- a/data/101/910/937/101910937.geojson
+++ b/data/101/910/937/101910937.geojson
@@ -139,6 +139,9 @@
         "wk:page":"\u010coka"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a961498ad68fc0ecd79538dc7d71af3d",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":101910937,
-    "wof:lastmodified":1563589053,
+    "wof:lastmodified":1582313339,
     "wof:name":"\u010coka",
     "wof:parent_id":1108809875,
     "wof:placetype":"locality",

--- a/data/101/910/961/101910961.geojson
+++ b/data/101/910/961/101910961.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Para\u0107in"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"774e5e9a84e19b8eee713390732d4b17",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":101910961,
-    "wof:lastmodified":1563589057,
+    "wof:lastmodified":1582313339,
     "wof:name":"Para\u0107in",
     "wof:parent_id":1108810023,
     "wof:placetype":"locality",

--- a/data/101/910/963/101910963.geojson
+++ b/data/101/910/963/101910963.geojson
@@ -143,6 +143,9 @@
         "wk:page":"\u0106uprija"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38f3ee85ffdfab2cd7be211530d5a60c",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101910963,
-    "wof:lastmodified":1563589054,
+    "wof:lastmodified":1582313339,
     "wof:name":"\u010cuprija",
     "wof:parent_id":1108809883,
     "wof:placetype":"locality",

--- a/data/101/910/965/101910965.geojson
+++ b/data/101/910/965/101910965.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Grocka"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"54819f434c491680c6157290e200c647",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101910965,
-    "wof:lastmodified":1563589052,
+    "wof:lastmodified":1582313339,
     "wof:name":"Grocka",
     "wof:parent_id":1108809899,
     "wof:placetype":"locality",

--- a/data/101/910/967/101910967.geojson
+++ b/data/101/910/967/101910967.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Kova\u010dica"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b94557ccad82511da14dec942c41104f",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":101910967,
-    "wof:lastmodified":1563589059,
+    "wof:lastmodified":1582313339,
     "wof:name":"Kova\u010dica",
     "wof:parent_id":1108809925,
     "wof:placetype":"locality",

--- a/data/101/910/971/101910971.geojson
+++ b/data/101/910/971/101910971.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Alibunar"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d6d0d64d556a206c5f3963a2f6d0e40d",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101910971,
-    "wof:lastmodified":1563589056,
+    "wof:lastmodified":1582313339,
     "wof:name":"Alibunar",
     "wof:parent_id":1108809813,
     "wof:placetype":"locality",

--- a/data/101/910/973/101910973.geojson
+++ b/data/101/910/973/101910973.geojson
@@ -155,6 +155,9 @@
         "wk:page":"Ba\u010dki Petrovac"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba1a5f61f28eee49cbfe6bd4cf1c05ec",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":101910973,
-    "wof:lastmodified":1563589062,
+    "wof:lastmodified":1582313339,
     "wof:name":"Ba\u010dki Petrovac",
     "wof:parent_id":1108809831,
     "wof:placetype":"locality",

--- a/data/101/910/977/101910977.geojson
+++ b/data/101/910/977/101910977.geojson
@@ -175,6 +175,9 @@
         "wk:page":"Ba\u010dka Palanka"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1890811a26fd3c779a4959d7d2201ff1",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":101910977,
-    "wof:lastmodified":1563589055,
+    "wof:lastmodified":1582313339,
     "wof:name":"Ba\u010dka Palanka",
     "wof:parent_id":1108809827,
     "wof:placetype":"locality",

--- a/data/101/910/979/101910979.geojson
+++ b/data/101/910/979/101910979.geojson
@@ -169,6 +169,9 @@
         "wk:page":"Vrbas, Serbia"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfc0f840154afe78adf1f2105916c62c",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":101910979,
-    "wof:lastmodified":1563589055,
+    "wof:lastmodified":1582313339,
     "wof:name":"Vrbas",
     "wof:parent_id":1108810149,
     "wof:placetype":"locality",

--- a/data/101/911/021/101911021.geojson
+++ b/data/101/911/021/101911021.geojson
@@ -257,6 +257,9 @@
         "wk:page":"Novi Pazar"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2239417bd65333507f2a0e58a4b9cd69",
     "wof:hierarchy":[
         {
@@ -269,7 +272,7 @@
         }
     ],
     "wof:id":101911021,
-    "wof:lastmodified":1563589048,
+    "wof:lastmodified":1582313339,
     "wof:name":"Novi Pazar",
     "wof:parent_id":1108810003,
     "wof:placetype":"locality",

--- a/data/101/911/025/101911025.geojson
+++ b/data/101/911/025/101911025.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Ra\u0161ka, Serbia"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"468b0d5903c9e1b2f6f7d332872c8303",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":101911025,
-    "wof:lastmodified":1563589043,
+    "wof:lastmodified":1582313339,
     "wof:name":"Ra\u00b5ka",
     "wof:parent_id":1108810051,
     "wof:placetype":"locality",

--- a/data/101/911/029/101911029.geojson
+++ b/data/101/911/029/101911029.geojson
@@ -149,6 +149,9 @@
         "wk:page":"Smederevska Palanka"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b548e946238ec5f72a4842e7e5205c4d",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101911029,
-    "wof:lastmodified":1563589047,
+    "wof:lastmodified":1582313339,
     "wof:name":"Smederevska Palanka",
     "wof:parent_id":1108810077,
     "wof:placetype":"locality",

--- a/data/101/911/137/101911137.geojson
+++ b/data/101/911/137/101911137.geojson
@@ -153,6 +153,9 @@
         "wd:id":"Q797036"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2908c11a89902211825434ae76f5d812",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":101911137,
-    "wof:lastmodified":1563589046,
+    "wof:lastmodified":1582313339,
     "wof:name":"Prijepolje",
     "wof:parent_id":1108810043,
     "wof:placetype":"locality",

--- a/data/101/911/579/101911579.geojson
+++ b/data/101/911/579/101911579.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Vrnja\u010dka Banja"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ad16e2c03b90e54d412c362cc56bbdf5",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":101911579,
-    "wof:lastmodified":1563589051,
+    "wof:lastmodified":1582313339,
     "wof:name":"Vrnja\u010dka Banja",
     "wof:parent_id":1108810151,
     "wof:placetype":"locality",

--- a/data/101/911/607/101911607.geojson
+++ b/data/101/911/607/101911607.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Ljig"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"17834b2e2c0eb79674e994babd7161f1",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":101911607,
-    "wof:lastmodified":1563589049,
+    "wof:lastmodified":1582313339,
     "wof:name":"Ljig",
     "wof:parent_id":1108809957,
     "wof:placetype":"locality",

--- a/data/101/911/609/101911609.geojson
+++ b/data/101/911/609/101911609.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Majdanpek"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0e19bf62d90cf93465b1b8f888d1a7c3",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101911609,
-    "wof:lastmodified":1563589049,
+    "wof:lastmodified":1582313339,
     "wof:name":"Majdanpek",
     "wof:parent_id":1108809967,
     "wof:placetype":"locality",

--- a/data/101/912/447/101912447.geojson
+++ b/data/101/912/447/101912447.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Kanji\u017ea"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"012e9ac46570916d4fba602d2e3d29e5",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":101912447,
-    "wof:lastmodified":1563589017,
+    "wof:lastmodified":1582313338,
     "wof:name":"Kanji\u017ea",
     "wof:parent_id":1108809911,
     "wof:placetype":"locality",

--- a/data/101/912/537/101912537.geojson
+++ b/data/101/912/537/101912537.geojson
@@ -317,6 +317,9 @@
         "wk:page":"Zrenjanin"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"9019e61a56e103aba8ede610a9df91ff",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         }
     ],
     "wof:id":101912537,
-    "wof:lastmodified":1563589023,
+    "wof:lastmodified":1582313338,
     "wof:name":"Zrenjanin",
     "wof:parent_id":1108810171,
     "wof:placetype":"locality",

--- a/data/101/912/619/101912619.geojson
+++ b/data/101/912/619/101912619.geojson
@@ -224,6 +224,9 @@
         "wk:page":"Po\u017earevac"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1804db839d05b61f34ddd33da9b7523c",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         }
     ],
     "wof:id":101912619,
-    "wof:lastmodified":1563589018,
+    "wof:lastmodified":1582313338,
     "wof:name":"Po\u017earevac",
     "wof:parent_id":1108810033,
     "wof:placetype":"locality",

--- a/data/101/912/623/101912623.geojson
+++ b/data/101/912/623/101912623.geojson
@@ -172,6 +172,9 @@
         "wk:page":"Petrovaradin"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ad148711446269be0d85a114c42c979a",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":101912623,
-    "wof:lastmodified":1563589027,
+    "wof:lastmodified":1582313338,
     "wof:name":"Petrovaradin",
     "wof:parent_id":1108810005,
     "wof:placetype":"locality",

--- a/data/101/913/175/101913175.geojson
+++ b/data/101/913/175/101913175.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Sur\u010din"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5b783e9de31bb1dace85c559bf54e1b",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":101913175,
-    "wof:lastmodified":1562015392,
+    "wof:lastmodified":1582313338,
     "wof:name":"Sur\u010din",
     "wof:parent_id":1108810099,
     "wof:placetype":"locality",

--- a/data/101/914/147/101914147.geojson
+++ b/data/101/914/147/101914147.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Zemun"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"077ec383c18e2b6806b9da84cbd26e6b",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":101914147,
-    "wof:lastmodified":1562023465,
+    "wof:lastmodified":1582313338,
     "wof:name":"Zemun",
     "wof:parent_id":1108809997,
     "wof:placetype":"locality",

--- a/data/101/914/183/101914183.geojson
+++ b/data/101/914/183/101914183.geojson
@@ -313,6 +313,9 @@
         "wk:page":"Ni\u0161"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8308a7aeea5b854ad8acdc5643ac65a0",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
         }
     ],
     "wof:id":101914183,
-    "wof:lastmodified":1563589040,
+    "wof:lastmodified":1582313338,
     "wof:name":"Ni\u00b5",
     "wof:parent_id":1108810015,
     "wof:placetype":"locality",

--- a/data/856/337/55/85633755.geojson
+++ b/data/856/337/55/85633755.geojson
@@ -991,6 +991,11 @@
     },
     "wof:country":"RS",
     "wof:country_alpha3":"SRB",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"2acdf69d3c6c507b46f7e700cad4034f",
     "wof:hierarchy":[
         {
@@ -1010,7 +1015,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733933,
+    "wof:lastmodified":1582313328,
     "wof:name":"Serbia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/882/23/85688223.geojson
+++ b/data/856/882/23/85688223.geojson
@@ -143,6 +143,9 @@
         "unlc:id":"RS-24"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66f6abc8ee25090ed2d306c4410e82d1",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313329,
     "wof:name":"P\u010dinjski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/25/85688225.geojson
+++ b/data/856/882/25/85688225.geojson
@@ -79,6 +79,9 @@
         "unlc:id":"RS-17"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3bd5be3f103602379471c9a96b7e2ee",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313330,
     "wof:name":"Moravi\u010dki upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/29/85688229.geojson
+++ b/data/856/882/29/85688229.geojson
@@ -309,6 +309,9 @@
         "wd:id":"Q648758"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e01ccfdf6b80a9cc0f405e9d8970d03f",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313329,
     "wof:name":"Severnoba\u010dki upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/33/85688233.geojson
+++ b/data/856/882/33/85688233.geojson
@@ -301,6 +301,9 @@
         "wd:id":"Q861539"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd301c2f47e1e08fa7b55f00ef1fb266",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313329,
     "wof:name":"Brani\u010devski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/39/85688239.geojson
+++ b/data/856/882/39/85688239.geojson
@@ -63,6 +63,9 @@
         "iso:id":"RS-05"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56896e52b75e6e842d1871ecb39fd6d9",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":85688239,
-    "wof:lastmodified":1536617285,
+    "wof:lastmodified":1582313329,
     "wof:name":"Minor islands of Serbia",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/43/85688243.geojson
+++ b/data/856/882/43/85688243.geojson
@@ -223,6 +223,9 @@
         "wd:id":"Q1043446"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68d91e5d6fec3f5637f997da6fb127f3",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313329,
     "wof:name":"Rasinski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/55/85688255.geojson
+++ b/data/856/882/55/85688255.geojson
@@ -232,6 +232,9 @@
         "wd:id":"Q478278"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6cb75943646be6fab74cd9c1e16b1606",
     "wof:hierarchy":[
         {
@@ -253,7 +256,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313329,
     "wof:name":"Zlatiborski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/57/85688257.geojson
+++ b/data/856/882/57/85688257.geojson
@@ -303,6 +303,9 @@
         "wd:id":"Q728041"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"496104ced47556ad57554392afc6b7ed",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313329,
     "wof:name":"Severnobanatski upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/61/85688261.geojson
+++ b/data/856/882/61/85688261.geojson
@@ -227,6 +227,9 @@
         "wd:id":"Q1048184"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37c09b5cb6855df3892115d14ad41b46",
     "wof:hierarchy":[
         {
@@ -248,7 +251,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313329,
     "wof:name":"Topli\u010dki upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/67/85688267.geojson
+++ b/data/856/882/67/85688267.geojson
@@ -226,6 +226,9 @@
         "wd:id":"Q778561"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"787fcf2b4ed7b8efc934b076f7376e1b",
     "wof:hierarchy":[
         {
@@ -247,7 +250,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313329,
     "wof:name":"Podunavski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/73/85688273.geojson
+++ b/data/856/882/73/85688273.geojson
@@ -143,6 +143,9 @@
         "unlc:id":"RS-18"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f5d6dc379e560e09ab715ed1657d799",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313329,
     "wof:name":"Ra\u0161ki upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/77/85688277.geojson
+++ b/data/856/882/77/85688277.geojson
@@ -143,6 +143,9 @@
         "unlc:id":"RS-15"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb9527d0ecec4bd9baf5d20309016ae7",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313329,
     "wof:name":"Zaje\u010darski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/79/85688279.geojson
+++ b/data/856/882/79/85688279.geojson
@@ -197,6 +197,9 @@
         "wd:id":"Q2074197"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f88f53dfe5dc78f1726ecb24cbcc3d8",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313329,
     "wof:name":"Grad Beograd",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/85/85688285.geojson
+++ b/data/856/882/85/85688285.geojson
@@ -300,6 +300,9 @@
         "wd:id":"Q1061076"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"edbdb3f621f658924b9854d681ec0e17",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313330,
     "wof:name":"Ni\u0161avski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/91/85688291.geojson
+++ b/data/856/882/91/85688291.geojson
@@ -237,6 +237,9 @@
         "wd:id":"Q217331"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2cc2a770a6e2bc972b4cffd4f787c14c",
     "wof:hierarchy":[
         {
@@ -258,7 +261,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313329,
     "wof:name":"Sremski upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/95/85688295.geojson
+++ b/data/856/882/95/85688295.geojson
@@ -315,6 +315,9 @@
         "wd:id":"Q648718"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efc7b375bac427666a898499522f779f",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313329,
     "wof:name":"Ju\u017enoba\u010dki upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/99/85688299.geojson
+++ b/data/856/882/99/85688299.geojson
@@ -238,6 +238,9 @@
         "wd:id":"Q425782"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"165e27b89eb004c9c115df55db153336",
     "wof:hierarchy":[
         {
@@ -259,7 +262,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733935,
+    "wof:lastmodified":1582313329,
     "wof:name":"Srednjobanatski upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/883/03/85688303.geojson
+++ b/data/856/883/03/85688303.geojson
@@ -220,6 +220,9 @@
         "wd:id":"Q580069"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ac725f4716176ff99e4d334ce04b852",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733933,
+    "wof:lastmodified":1582313328,
     "wof:name":"Pirotski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/09/85688309.geojson
+++ b/data/856/883/09/85688309.geojson
@@ -223,6 +223,9 @@
         "wd:id":"Q867816"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fe6e1e2ddd3f406179e58b488e189677",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313328,
     "wof:name":"Pomoravski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/13/85688313.geojson
+++ b/data/856/883/13/85688313.geojson
@@ -299,6 +299,9 @@
         "wd:id":"Q1048139"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6881d0e9dc1d7f2971e47f5d9e08623",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313329,
     "wof:name":"Kolubarski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/19/85688319.geojson
+++ b/data/856/883/19/85688319.geojson
@@ -143,6 +143,9 @@
         "unlc:id":"RS-12"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98e57d70d9f77d761f6bba4153b3e6e0",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313328,
     "wof:name":"\u0160umadijski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/21/85688321.geojson
+++ b/data/856/883/21/85688321.geojson
@@ -145,6 +145,9 @@
         "unlc:id":"RS-04"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"deb795bd6acf86474cbb5562f7515764",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313328,
     "wof:name":"Ju\u017enobanatski upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/883/29/85688329.geojson
+++ b/data/856/883/29/85688329.geojson
@@ -306,6 +306,9 @@
         "wd:id":"Q876541"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"482a7c202f12a29849acb2231c6cf29a",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733933,
+    "wof:lastmodified":1582313328,
     "wof:name":"Jablani\u010dki upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/31/85688331.geojson
+++ b/data/856/883/31/85688331.geojson
@@ -300,6 +300,9 @@
         "wd:id":"Q477586"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"71064c45100aefa24cf889effcb7013b",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733934,
+    "wof:lastmodified":1582313328,
     "wof:name":"Borski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/35/85688335.geojson
+++ b/data/856/883/35/85688335.geojson
@@ -143,6 +143,9 @@
         "unlc:id":"RS-08"
     },
     "wof:country":"RS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4b59d377ebce4a70838e7be60e20c89",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1565733933,
+    "wof:lastmodified":1582313328,
     "wof:name":"Ma\u010dvanski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/890/476/941/890476941.geojson
+++ b/data/890/476/941/890476941.geojson
@@ -699,6 +699,10 @@
     },
     "wof:country":"RS",
     "wof:created":1469054095,
+    "wof:geom_alt":[
+        "meso",
+        "unknown"
+    ],
     "wof:geomhash":"754859d2e5782893aaad1417de8238a8",
     "wof:hierarchy":[
         {
@@ -711,7 +715,7 @@
         }
     ],
     "wof:id":890476941,
-    "wof:lastmodified":1563589149,
+    "wof:lastmodified":1582313340,
     "wof:name":"Belgrade",
     "wof:parent_id":1108810063,
     "wof:placetype":"locality",

--- a/data/890/477/295/890477295.geojson
+++ b/data/890/477/295/890477295.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"RS",
     "wof:created":1469054110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"397b13e144a67657fcb67298936d9449",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890477295,
-    "wof:lastmodified":1527727179,
+    "wof:lastmodified":1582313341,
     "wof:name":"Pirot",
     "wof:parent_id":85688303,
     "wof:placetype":"county",

--- a/data/890/477/309/890477309.geojson
+++ b/data/890/477/309/890477309.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"RS",
     "wof:created":1469054110,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c17bf8e2996d8027e74ee47004406bc6",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":890477309,
-    "wof:lastmodified":1527727176,
+    "wof:lastmodified":1582313340,
     "wof:name":"Lajkovac",
     "wof:parent_id":85688329,
     "wof:placetype":"county",

--- a/data/890/477/399/890477399.geojson
+++ b/data/890/477/399/890477399.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"RS",
     "wof:created":1469054113,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1cbb0d575a76b9d74289c0e823692f94",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890477399,
-    "wof:lastmodified":1527727177,
+    "wof:lastmodified":1582313340,
     "wof:name":"Vranje",
     "wof:parent_id":85688223,
     "wof:placetype":"county",

--- a/data/890/477/405/890477405.geojson
+++ b/data/890/477/405/890477405.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"RS",
     "wof:created":1469054113,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"80e6d0cd29e92e389d1ed9d2ac1fc8ca",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890477405,
-    "wof:lastmodified":1527727185,
+    "wof:lastmodified":1582313341,
     "wof:name":"Prokuplje",
     "wof:parent_id":85688261,
     "wof:placetype":"county",

--- a/data/890/477/407/890477407.geojson
+++ b/data/890/477/407/890477407.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"RS",
     "wof:created":1469054113,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a1f3101d40e79819e017b3e7777abac",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890477407,
-    "wof:lastmodified":1527727180,
+    "wof:lastmodified":1582313341,
     "wof:name":"Kraljevo",
     "wof:parent_id":85688273,
     "wof:placetype":"county",

--- a/data/890/477/425/890477425.geojson
+++ b/data/890/477/425/890477425.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"RS",
     "wof:created":1469054115,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7c27cdf915d3ed9bf383d96279f0fcd",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":890477425,
-    "wof:lastmodified":1507676881,
+    "wof:lastmodified":1582313340,
     "wof:name":"Bor",
     "wof:parent_id":85688331,
     "wof:placetype":"county",

--- a/data/890/477/441/890477441.geojson
+++ b/data/890/477/441/890477441.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"RS",
     "wof:created":1469054115,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e38da43cabc7eb856a9cf0965afae1f1",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890477441,
-    "wof:lastmodified":1527727179,
+    "wof:lastmodified":1582313341,
     "wof:name":"Valjevo",
     "wof:parent_id":85688313,
     "wof:placetype":"county",

--- a/data/890/477/543/890477543.geojson
+++ b/data/890/477/543/890477543.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"RS",
     "wof:created":1469054120,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a7d9bb3176dd43fa4828859a0f9418b",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890477543,
-    "wof:lastmodified":1527727181,
+    "wof:lastmodified":1582313341,
     "wof:name":"Kikinda",
     "wof:parent_id":85688257,
     "wof:placetype":"county",

--- a/data/890/477/619/890477619.geojson
+++ b/data/890/477/619/890477619.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"RS",
     "wof:created":1469054123,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8344d7b613251e5eb12c1a4e8bfeedb0",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890477619,
-    "wof:lastmodified":1527727178,
+    "wof:lastmodified":1582313340,
     "wof:name":"Sabac",
     "wof:parent_id":85688335,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.