### PR TITLE
Update properties of megacities

### DIFF
--- a/data/890/476/941/890476941.geojson
+++ b/data/890/476/941/890476941.geojson
@@ -694,6 +694,7 @@
     "wof:concordances":{
         "gn:id":792680,
         "gp:id":532697,
+        "ne:id":1159151079,
         "qs_pg:id":275778,
         "wd:id":"Q3711",
         "wk:page":"Belgrade"
@@ -716,7 +717,8 @@
         }
     ],
     "wof:id":890476941,
-    "wof:lastmodified":1607390896,
+    "wof:lastmodified":1608688179,
+    "wof:megacity":1,
     "wof:name":"Belgrade",
     "wof:parent_id":1108810063,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary