### PR TITLE
rs concordances, placetype local, and more

### DIFF
--- a/data/404/227/537/404227537.geojson
+++ b/data/404/227/537/404227537.geojson
@@ -332,8 +332,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS1",
+        "iso:code":"RS-VO",
         "wd:id":"Q44749"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"RS",
     "wof:geomhash":"b7f02baa26cb46036a9de3fe27834a17",
     "wof:hierarchy":[
@@ -355,7 +357,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1694493066,
+    "wof:lastmodified":1695884171,
     "wof:name":"Vojvodina",
     "wof:parent_id":85633755,
     "wof:placetype":"macroregion",

--- a/data/404/228/357/404228357.geojson
+++ b/data/404/228/357/404228357.geojson
@@ -177,7 +177,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1694493048,
+    "wof:lastmodified":1695884142,
     "wof:name":"Central Serbia",
     "wof:parent_id":85633755,
     "wof:placetype":"macroregion",

--- a/data/856/337/55/85633755.geojson
+++ b/data/856/337/55/85633755.geojson
@@ -1192,6 +1192,7 @@
         "hasc:id":"RS",
         "icao:code":"YU",
         "ioc:id":"SRB",
+        "iso:code":"RS",
         "itu:id":"SRB",
         "loc:id":"n85195919",
         "m49:code":"688",
@@ -1206,6 +1207,7 @@
         "wk:page":"Serbia",
         "wmo:id":"YG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"RS",
     "wof:country_alpha3":"SRB",
     "wof:created":1652212540,
@@ -1234,7 +1236,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1694492241,
+    "wof:lastmodified":1695881354,
     "wof:name":"Serbia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/882/23/85688223.geojson
+++ b/data/856/882/23/85688223.geojson
@@ -161,9 +161,15 @@
         "gn:id":7581802,
         "gp:id":29389215,
         "hasc:id":"RS.PC",
+        "iso:code":"RS-24",
         "iso:id":"RS-24",
+        "qs:local_id":"018",
         "unlc:id":"RS-24"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +195,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1684351671,
+    "wof:lastmodified":1695885315,
     "wof:name":"P\u010dinjski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/25/85688225.geojson
+++ b/data/856/882/25/85688225.geojson
@@ -97,9 +97,15 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS214",
         "hasc:id":"RS.MR",
+        "iso:code":"RS-17",
         "iso:id":"RS-17",
+        "qs:local_id":"011",
         "unlc:id":"RS-17"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
@@ -125,7 +131,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1684351671,
+    "wof:lastmodified":1695885315,
     "wof:name":"Moravi\u010dki upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/29/85688229.geojson
+++ b/data/856/882/29/85688229.geojson
@@ -338,15 +338,21 @@
         "gn:id":7581808,
         "gp:id":29389196,
         "hasc:id":"RS.SC",
+        "iso:code":"RS-01",
         "iso:id":"RS-01",
+        "qs:local_id":"101",
         "unlc:id":"RS-01",
         "wd:id":"Q648758"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a3e9bf85cf163812e7ae30cea06cce76",
+    "wof:geomhash":"7e63145e1b5fcf710a5b473d2186bb1c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -367,7 +373,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858530,
+    "wof:lastmodified":1695885315,
     "wof:name":"Severnoba\u010dki upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/33/85688233.geojson
+++ b/data/856/882/33/85688233.geojson
@@ -327,15 +327,21 @@
         "gn:id":7581794,
         "gp:id":29389198,
         "hasc:id":"RS.BR",
+        "iso:code":"RS-11",
         "iso:id":"RS-11",
+        "qs:local_id":"005",
         "unlc:id":"RS-11",
         "wd:id":"Q861539"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1cd35e73200f7dde061799e58a7af96a",
+    "wof:geomhash":"16fb461e92d92be411c81df292239ed2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -356,7 +362,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858530,
+    "wof:lastmodified":1695885315,
     "wof:name":"Brani\u010devski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/43/85688243.geojson
+++ b/data/856/882/43/85688243.geojson
@@ -255,15 +255,21 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS216",
         "hasc:id":"RS.RN",
+        "iso:code":"RS-19",
         "iso:id":"RS-19",
+        "qs:local_id":"013",
         "unlc:id":"RS-19",
         "wd:id":"Q1043446"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2ab215cce08aa60b07d709df5959ce35",
+    "wof:geomhash":"3ce07b3f0275350926914f52a7ee3779",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -284,7 +290,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858530,
+    "wof:lastmodified":1695885315,
     "wof:name":"Rasinski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/49/85688249.geojson
+++ b/data/856/882/49/85688249.geojson
@@ -84,8 +84,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS121",
+        "iso:code":"RS-05",
+        "qs:local_id":"105",
         "unlc:id":"RS-05"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geomhash":"8f0d57ad5e4ba3c0c922114b83d3731e",
     "wof:hierarchy":[
@@ -108,7 +114,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1694639831,
+    "wof:lastmodified":1695884322,
     "wof:name":"Zapadnoba\u010dki upravni",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/55/85688255.geojson
+++ b/data/856/882/55/85688255.geojson
@@ -264,15 +264,21 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS211",
         "hasc:id":"RS.ZL",
+        "iso:code":"RS-16",
         "iso:id":"RS-16",
+        "qs:local_id":"010",
         "unlc:id":"RS-16",
         "wd:id":"Q478278"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ef06d2ae627840bb576f2716d42e24f3",
+    "wof:geomhash":"e733ab35b00de3219d67c8dec1e41352",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -293,7 +299,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858531,
+    "wof:lastmodified":1695885315,
     "wof:name":"Zlatiborski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/57/85688257.geojson
+++ b/data/856/882/57/85688257.geojson
@@ -329,15 +329,21 @@
         "gn:id":7581905,
         "gp:id":29389203,
         "hasc:id":"RS.SN",
+        "iso:code":"RS-03",
         "iso:id":"RS-03",
+        "qs:local_id":"103",
         "unlc:id":"RS-03",
         "wd:id":"Q728041"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ffc1499319a87addda2e2cbebead36c0",
+    "wof:geomhash":"2951be4051007a2db1301ae64f9d3c40",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -358,7 +364,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858529,
+    "wof:lastmodified":1695885315,
     "wof:name":"Severnobanatski upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/61/85688261.geojson
+++ b/data/856/882/61/85688261.geojson
@@ -253,15 +253,21 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS229",
         "hasc:id":"RS.TO",
+        "iso:code":"RS-21",
         "iso:id":"RS-21",
+        "qs:local_id":"015",
         "unlc:id":"RS-21",
         "wd:id":"Q1048184"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c0dc8392c6a0e6289941c813591660a3",
+    "wof:geomhash":"6f77b98d3e0d578c8f0aa215b844c817",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -282,7 +288,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858529,
+    "wof:lastmodified":1695885315,
     "wof:name":"Topli\u010dki upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/67/85688267.geojson
+++ b/data/856/882/67/85688267.geojson
@@ -252,15 +252,21 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS227",
         "hasc:id":"RS.PD",
+        "iso:code":"RS-10",
         "iso:id":"RS-10",
+        "qs:local_id":"004",
         "unlc:id":"RS-10",
         "wd:id":"Q778561"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f03b2e83b12cf9d2a07f1d93698036fc",
+    "wof:geomhash":"99423ac457daeb401256380aee40eda9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -281,7 +287,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858529,
+    "wof:lastmodified":1695885315,
     "wof:name":"Podunavski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/73/85688273.geojson
+++ b/data/856/882/73/85688273.geojson
@@ -161,9 +161,15 @@
         "gn:id":7581807,
         "gp:id":29389224,
         "hasc:id":"RS.RS",
+        "iso:code":"RS-18",
         "iso:id":"RS-18",
+        "qs:local_id":"012",
         "unlc:id":"RS-18"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +195,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1684351671,
+    "wof:lastmodified":1695885315,
     "wof:name":"Ra\u0161ki upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/77/85688277.geojson
+++ b/data/856/882/77/85688277.geojson
@@ -161,9 +161,15 @@
         "gn:id":7581910,
         "gp:id":29389213,
         "hasc:id":"RS.ZJ",
+        "iso:code":"RS-15",
         "iso:id":"RS-15",
+        "qs:local_id":"009",
         "unlc:id":"RS-15"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +195,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1684351671,
+    "wof:lastmodified":1695885315,
     "wof:name":"Zaje\u010darski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/79/85688279.geojson
+++ b/data/856/882/79/85688279.geojson
@@ -230,15 +230,21 @@
         "gn:id":8199669,
         "gp:id":29389217,
         "hasc:id":"RS.BG",
+        "iso:code":"RS-00",
         "iso:id":"RS-00",
+        "qs:local_id":"001",
         "unlc:id":"RS-00",
         "wd:id":"Q2074197"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eafd166bfddf4c8543e93dd3cd8a0f3f",
+    "wof:geomhash":"51dc44f47520819893e39393693c9a3a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -259,7 +265,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858531,
+    "wof:lastmodified":1695885315,
     "wof:name":"Grad Beograd",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/85/85688285.geojson
+++ b/data/856/882/85/85688285.geojson
@@ -323,15 +323,21 @@
         "gn:id":7581801,
         "gp:id":29389223,
         "hasc:id":"RS.NS",
+        "iso:code":"RS-20",
         "iso:id":"RS-20",
+        "qs:local_id":"014",
         "unlc:id":"RS-20",
         "wd:id":"Q1061076"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"25f15655bffe002df0854c3ebfc74b2a",
+    "wof:geomhash":"ee8fa4dcffc16157c26a179fc7f3e6a0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -352,7 +358,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858532,
+    "wof:lastmodified":1695885315,
     "wof:name":"Ni\u0161avski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/882/91/85688291.geojson
+++ b/data/856/882/91/85688291.geojson
@@ -263,15 +263,21 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS127",
         "hasc:id":"RS.SM",
+        "iso:code":"RS-07",
         "iso:id":"RS-07",
+        "qs:local_id":"107",
         "unlc:id":"RS-07",
         "wd:id":"Q217331"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bdbb43bb8a81bae45f9ff70b190224f5",
+    "wof:geomhash":"8439ffacdc2d69c9a00b2d3635fb0434",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -292,7 +298,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858531,
+    "wof:lastmodified":1695885315,
     "wof:name":"Sremski upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/95/85688295.geojson
+++ b/data/856/882/95/85688295.geojson
@@ -345,14 +345,20 @@
         "gn:id":7581796,
         "gp:id":29389212,
         "hasc:id":"RS.JC",
+        "iso:code":"RS-06",
         "iso:id":"RS-06",
+        "qs:local_id":"106",
         "wd:id":"Q648718"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a78863f81c9dc76d8dde96e682ab4fc0",
+    "wof:geomhash":"cc5c716a0406592751d6b5ae314c9cbe",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -373,7 +379,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858529,
+    "wof:lastmodified":1695885315,
     "wof:name":"Ju\u017enoba\u010dki upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/882/99/85688299.geojson
+++ b/data/856/882/99/85688299.geojson
@@ -268,14 +268,20 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS126",
         "hasc:id":"RS.SD",
+        "iso:code":"RS-02",
         "iso:id":"RS-02",
+        "qs:local_id":"102",
         "wd:id":"Q425782"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"70faf0ad897be69be98540b846a0f7cf",
+    "wof:geomhash":"ac79455c82ad68215205f173c9306fff",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -296,7 +302,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858531,
+    "wof:lastmodified":1695885315,
     "wof:name":"Srednjobanatski upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/883/03/85688303.geojson
+++ b/data/856/883/03/85688303.geojson
@@ -246,15 +246,21 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS226",
         "hasc:id":"RS.PI",
+        "iso:code":"RS-22",
         "iso:id":"RS-22",
+        "qs:local_id":"016",
         "unlc:id":"RS-22",
         "wd:id":"Q580069"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"52c34702392e4341311d732fd62e6ee2",
+    "wof:geomhash":"12d3f42284c4e46ea99f4ba13ceb860c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -275,7 +281,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858527,
+    "wof:lastmodified":1695885316,
     "wof:name":"Pirotski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/09/85688309.geojson
+++ b/data/856/883/09/85688309.geojson
@@ -255,15 +255,21 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"RS215",
         "hasc:id":"RS.PM",
+        "iso:code":"RS-13",
         "iso:id":"RS-13",
+        "qs:local_id":"007",
         "unlc:id":"RS-13",
         "wd:id":"Q867816"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67f7a16488eb019b02294fa8593ea783",
+    "wof:geomhash":"e19619f43b8a38b8a57069b547a44c47",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -284,7 +290,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858528,
+    "wof:lastmodified":1695885316,
     "wof:name":"Pomoravski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/13/85688313.geojson
+++ b/data/856/883/13/85688313.geojson
@@ -322,15 +322,21 @@
         "gn:id":7581798,
         "gp:id":29389220,
         "hasc:id":"RS.KB",
+        "iso:code":"RS-09",
         "iso:id":"RS-09",
+        "qs:local_id":"003",
         "unlc:id":"RS-09",
         "wd:id":"Q1048139"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ff0849a9eab89511ad4319a28d8827f6",
+    "wof:geomhash":"a58d9a41a2735c753442729564d3a88e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -351,7 +357,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858528,
+    "wof:lastmodified":1695885316,
     "wof:name":"Kolubarski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/19/85688319.geojson
+++ b/data/856/883/19/85688319.geojson
@@ -159,9 +159,15 @@
         "gn:id":7581908,
         "gp:id":29389225,
         "hasc:id":"RS.SU",
+        "iso:code":"RS-12",
         "iso:id":"RS-12",
+        "qs:local_id":"006",
         "unlc:id":"RS-12"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
@@ -187,7 +193,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695885316,
     "wof:name":"\u0160umadijski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/21/85688321.geojson
+++ b/data/856/883/21/85688321.geojson
@@ -163,9 +163,15 @@
         "gn:id":7581797,
         "gp:id":29389222,
         "hasc:id":"RS.JN",
+        "iso:code":"RS-04",
         "iso:id":"RS-04",
+        "qs:local_id":"104",
         "unlc:id":"RS-04"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
@@ -191,7 +197,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695885316,
     "wof:name":"Ju\u017enobanatski upravni okrug",
     "wof:parent_id":404227537,
     "wof:placetype":"region",

--- a/data/856/883/29/85688329.geojson
+++ b/data/856/883/29/85688329.geojson
@@ -329,15 +329,21 @@
         "gn:id":7581795,
         "gp:id":29389208,
         "hasc:id":"RS.JA",
+        "iso:code":"RS-23",
         "iso:id":"RS-23",
+        "qs:local_id":"017",
         "unlc:id":"RS-23",
         "wd:id":"Q876541"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7619746948b24cfc3b78e7f560a3daf2",
+    "wof:geomhash":"b1cccc45dd0e16a8cdc1100fc1eb4454",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -358,7 +364,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858527,
+    "wof:lastmodified":1695885316,
     "wof:name":"Jablani\u010dki upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/31/85688331.geojson
+++ b/data/856/883/31/85688331.geojson
@@ -329,15 +329,21 @@
         "gn:id":7581582,
         "gp:id":29389206,
         "hasc:id":"RS.BO",
+        "iso:code":"RS-14",
         "iso:id":"RS-14",
+        "qs:local_id":"008",
         "unlc:id":"RS-14",
         "wd:id":"Q477586"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"94f1ee9fe4ff406bb1993dab5927c7d5",
+    "wof:geomhash":"76f8bae47deb35afadb43437c2ab1429",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -358,7 +364,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1690858528,
+    "wof:lastmodified":1695885316,
     "wof:name":"Borski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",

--- a/data/856/883/35/85688335.geojson
+++ b/data/856/883/35/85688335.geojson
@@ -161,9 +161,15 @@
         "gn:id":7581799,
         "gp:id":29389202,
         "hasc:id":"RS.MA",
+        "iso:code":"RS-08",
         "iso:id":"RS-08",
+        "qs:local_id":"002",
         "unlc:id":"RS-08"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"RS",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +195,7 @@
         "slk",
         "ukr"
     ],
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695885316,
     "wof:name":"Ma\u010dvanski upravni okrug",
     "wof:parent_id":404228357,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.